### PR TITLE
feat: use regex pattern to match resource type in autocomplete

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -9,9 +9,7 @@
       "x-schema-form": {
         "event": {
           "name": "fetch-resources",
-          "types": [
-            "cache"
-          ]
+          "regexTypes": "^cache$"
         }
       }
     },


### PR DESCRIPTION
fix gravitee-io/issues#3895