### PR TITLE
fix: manage encoding content

### DIFF
--- a/src/main/java/io/gravitee/policy/cache/mapper/CacheResponseMapper.java
+++ b/src/main/java/io/gravitee/policy/cache/mapper/CacheResponseMapper.java
@@ -25,6 +25,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.buffer.BufferFactory;
 import io.gravitee.gateway.buffer.netty.BufferFactoryImpl;
 import java.io.IOException;
+import java.util.Base64;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -58,7 +59,7 @@ public class CacheResponseMapper extends ObjectMapper {
         public Buffer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             JsonNode node = p.getCodec().readTree(p);
             if (node.has("buffer")) {
-                return factory.buffer(node.get("buffer").asText());
+                return factory.buffer(Base64.getDecoder().decode(node.get("buffer").asText()));
             }
             return null;
         }
@@ -69,7 +70,7 @@ public class CacheResponseMapper extends ObjectMapper {
         @Override
         public void serialize(Buffer value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
             gen.writeStartObject();
-            gen.writeStringField("buffer", value.toString());
+            gen.writeStringField("buffer", Base64.getEncoder().encodeToString(value.getBytes()));
             gen.writeEndObject();
         }
     }

--- a/src/test/java/io/gravitee/policy/cache/mapper/CacheResponseMapperTest.java
+++ b/src/test/java/io/gravitee/policy/cache/mapper/CacheResponseMapperTest.java
@@ -15,13 +15,21 @@
  */
 package io.gravitee.policy.cache.mapper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.gravitee.common.http.HttpHeaders;
-import io.gravitee.gateway.api.buffer.BufferFactory;
-import io.gravitee.gateway.buffer.netty.BufferFactoryImpl;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.policy.cache.CacheResponse;
-import org.junit.Assert;
-import org.junit.Before;
+import io.gravitee.policy.cache.mapper.CacheResponseMapper;
+import io.gravitee.policy.cache.resource.CacheElement;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -33,57 +41,39 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class CacheResponseMapperTest {
 
-    CacheResponseMapper cacheResponseMapper = new CacheResponseMapper();
-    BufferFactory factory = new BufferFactoryImpl();
-    CacheResponse cacheResponse = new CacheResponse();
+    CacheResponseMapper mapper = new CacheResponseMapper();
 
-    @Before
-    public void setup() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.set("Authentication", "Bearer: hackathon");
-        httpHeaders.set("Content-Type", "application/json");
-        cacheResponse.setHeaders(httpHeaders);
-        cacheResponse.setContent(factory.buffer("foobar"));
-        cacheResponse.setStatus(200);
+    private static byte[] compress(String str) throws Exception {
+        if (str == null || str.length() == 0) {
+            return new byte[0];
+        }
+        ByteArrayOutputStream obj = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(obj);
+        gzip.write(str.getBytes(StandardCharsets.UTF_8));
+        gzip.close();
+        return obj.toByteArray();
+    }
+
+    public static String decompress(byte[] bytes) throws Exception {
+        GZIPInputStream gis = new GZIPInputStream(new ByteArrayInputStream(bytes));
+
+        return new BufferedReader(new InputStreamReader(gis, StandardCharsets.UTF_8)).lines().collect(Collectors.joining("\n"));
     }
 
     @Test
-    public void shouldSerialize() throws JsonProcessingException {
-        String responseAsString = cacheResponseMapper.writeValueAsString(cacheResponse);
+    public void shouldReadCacheResponseWithCompressContent() throws Exception {
+        String content = "foobar";
+        Buffer buffer = Buffer.buffer(compress(content));
+        CacheResponse response = new CacheResponse();
+        response.setContent(buffer);
+        CacheElement element = new CacheElement("key", mapper.writeValueAsString(response));
 
-        Assert.assertEquals(
-            responseAsString,
-            "{\n" +
-            "  \"status\" : 200,\n" +
-            "  \"headers\" : {\n" +
-            "    \"Authentication\" : [ \"Bearer: hackathon\" ],\n" +
-            "    \"Content-Type\" : [ \"application/json\" ]\n" +
-            "  },\n" +
-            "  \"content\" : {\n" +
-            "    \"buffer\" : \"foobar\"\n" +
-            "  }\n" +
-            "}"
-        );
-    }
+        assertNotNull(element);
 
-    @Test
-    public void shouldDeserialize() throws JsonProcessingException {
-        CacheResponse response = cacheResponseMapper.readValue(
-            "{\n" +
-            "  \"status\" : 200,\n" +
-            "  \"headers\" : {\n" +
-            "    \"Authentication\" : [ \"Bearer: hackathon\" ],\n" +
-            "    \"Content-Type\" : [ \"application/json\" ]\n" +
-            "  },\n" +
-            "  \"content\" : {\n" +
-            "    \"buffer\" : \"foobar\"\n" +
-            "  }\n" +
-            "}",
-            CacheResponse.class
-        );
+        CacheResponse cacheResponse = mapper.readValue(element.value().toString(), CacheResponse.class);
+        assertNotNull(cacheResponse);
 
-        Assert.assertEquals(response.getContent().toString(), cacheResponse.getContent().toString());
-        Assert.assertEquals(response.getHeaders(), cacheResponse.getHeaders());
-        Assert.assertEquals(response.getStatus(), cacheResponse.getStatus());
+        String contentUncompressed = decompress(cacheResponse.getContent().getBytes());
+        assertEquals(content, contentUncompressed);
     }
 }


### PR DESCRIPTION
gravitee-io/issues#6967

This solution works but increases the memory size for the data. 
We could add a condition based on the header `Content-Encoding` what do you think @gravitee-io/apim ?