### PR TITLE
fix: use query parameters when hashing cache key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.10</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
-        <gravitee-apim-gateway.version>3.17.3</gravitee-apim-gateway.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-apim-gateway.version>3.18.10</gravitee-apim-gateway.version>
+        <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-cache-provider-api.version>1.1.0</gravitee-resource-cache-provider-api.version>
@@ -101,6 +101,13 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${gravitee-apim-gateway.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-reactor</artifactId>
             <version>${gravitee-apim-gateway.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/8366
see https://graviteecommunity.atlassian.net/browse/APIM-77

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.15.2-8366-cache-query-params-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/1.15.2-8366-cache-query-params-SNAPSHOT/gravitee-policy-cache-1.15.2-8366-cache-query-params-SNAPSHOT.zip)
  <!-- Version placeholder end -->
