### PR TITLE
Introduce a binary serialization mode to deal with encoding issue

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,3 +94,19 @@ TIP: To learn more about the Gravitee Expression Language, see the *API Publishe
     "responseCondition": "{#upstreamResponse.status == 201}"
 }
 ----
+
+
+=== Gateway configuration (gravitee.yml)
+
+WARNING: The `binary` serialization format is not compatible with the Redis cache resource.
+
+[source, yaml]
+----
+  policy:
+    cache:
+      serialization: text # default value or "binary" (not compatible with Redis)
+----
+
+The `policy.cache.serialization` allow to configure the serialization format of the cache.
+
+The default value is `text` but you can also use `binary` to use a binary serialization format (not compatible with Redis).

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-cache</artifactId>
-    <version>1.15.2</version>
+    <version>1.16.0</version>
 
     <name>Gravitee.io APIM - Policy - Caching</name>
     <description>Description of the Cache Gravitee Policy</description>

--- a/src/main/java/io/gravitee/policy/cache/configuration/SerializationMode.java
+++ b/src/main/java/io/gravitee/policy/cache/configuration/SerializationMode.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.cache.configuration;
+
+/**
+ * BINARY mode allow to serialize by ignoring the default charset used by the buffer.
+ * WARNING: BINARY mode does NOT work with REDIS resource cache.
+ */
+public enum SerializationMode {
+    /**
+     * Serialize the cache response as a text.
+     */
+    TEXT,
+    /**
+     * Serialize the cache response as a binary.
+     * WARNING: This mode does NOT work with REDIS resource cache.
+     */
+    BINARY,
+}

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyTest.java
@@ -44,6 +44,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -74,6 +76,7 @@ public class CachePolicyTest {
     @Before
     public void init() {
         MockitoAnnotations.openMocks(this);
+        when(executionContext.getComponent(Environment.class)).thenReturn(new MockEnvironment());
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-179
https://github.com/gravitee-io/issues/issues/8561


**Description**

Introduce a binary serialization mode to deal with encoding issue
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.16.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/1.16.0/gravitee-policy-cache-1.16.0.zip)
  <!-- Version placeholder end -->
