### PR TITLE
Clean and validate json schema for v4

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,68 +1,77 @@
 {
-  "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:cache:configuration:CachePolicyConfiguration",
-  "properties": {
-    "cacheName": {
-      "title": "Cache name",
-      "description": "The cache resource used to store the element.",
-      "type": "string",
-      "x-schema-form": {
-        "event": {
-          "name": "fetch-resources",
-          "regexTypes": "^cache"
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "cacheName": {
+            "title": "Cache name",
+            "description": "The cache resource used to store the element.",
+            "type": "string",
+            "x-schema-form": {
+                "event": {
+                    "name": "fetch-resources",
+                    "regexTypes": "^cache"
+                }
+            },
+            "gioConfig": {
+                "uiType": "policy-cache-resource"
+            }
+        },
+        "key": {
+            "title": "Key",
+            "description": "The key used to store the element (Support EL).",
+            "type": "string",
+            "x-schema-form": {
+                "expression-language": true
+            }
+        },
+        "timeToLiveSeconds": {
+            "title": "Time to live (in seconds)",
+            "default": 600,
+            "description": "Time to live of the element put in cache (Default to 10 minutes).",
+            "type": "integer"
+        },
+        "methods": {
+            "title": "Methods to cache",
+            "description": "Select which method you want to cache.",
+            "type": "array",
+            "default": ["GET", "OPTIONS", "HEAD"],
+            "items": {
+                "type": "string",
+                "enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
+            }
+        },
+        "responseCondition": {
+            "title": "Response Condition",
+            "description": "(Support EL)",
+            "type": "string",
+            "x-schema-form": {
+                "expression-language": true
+            },
+            "gioConfig": {
+              "banner": {
+                "title": "Response Condition",
+                "text": "Add an extra condition (with Expression Language) based on the response to activate cache.<br>For example use <strong>{#upstreamResponse.status == 200}</strong> to only cache 200 responses status. By default, 2xx only are cached.<br> \uD83D\uDEA8 <code>upstreamResponse.content</code> is not supported."
+              }
+            }
+        },
+        "useResponseCacheHeaders": {
+            "title": "Use response headers",
+            "description": "Time to live based on 'Cache-Control' and / or 'Expires' headers from response.",
+            "type": "boolean"
+        },
+        "scope": {
+            "title": "Scope",
+            "type": "string",
+            "default": "APPLICATION",
+            "enum": ["API", "APPLICATION"],
+            "gioConfig": {
+              "banner": {
+                "title": "Scope",
+                "text": "Cached response can be set for a single consumer (application) or for all consumers.<br><strong>WARNING:</strong> Please be aware that by using an \"API\" scope, data will be shared between all consumers!"
+              }
+            }
         }
-      }
     },
-    "key": {
-      "title": "Key",
-      "description": "The key used to store the element (Support EL).",
-      "type": "string",
-      "x-schema-form": {
-        "expression-language": true
-      }
-    },
-    "timeToLiveSeconds": {
-      "title": "Time to live (in seconds)",
-      "default": 600,
-      "description": "Time to live of the element put in cache (Default to 10 minutes).",
-      "type": "integer"
-    },
-    "methods": {
-      "title": "Methods to cache",
-      "description": "Select which method you want to cache.",
-      "type": "array",
-      "default": ["GET", "OPTIONS", "HEAD"],
-      "items" : {
-        "type" : "string",
-        "enum" : [ "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" ]
-      }
-    },
-    "responseCondition" : {
-      "title": "Response Condition",
-      "description": "Add an extra condition (with Expression Language) based on the response to activate cache.<br>For example use <strong>{#upstreamResponse.status == 200}</strong> to only cache 200 responses status. By default, 2xx only are cached.<br> \uD83D\uDEA8 <code>upstreamResponse.content</code> is not supported.",
-      "type" : "string",
-      "x-schema-form": {
-        "expression-language": true
-      }
-    },
-    "useResponseCacheHeaders": {
-      "title": "Use response headers",
-      "description": "Time to live based on 'Cache-Control' and / or 'Expires' headers from response.",
-      "type": "boolean"
-    },
-    "scope": {
-      "title": "Scope",
-      "description": "Cached response can be set for a single consumer (application) or for all consumers.<br><strong>WARNING:</strong> Please be aware that by using an \"API\" scope, data will be shared between all consumers!",
-      "type": "string",
-      "default": "APPLICATION",
-      "enum": [
-        "API",
-        "APPLICATION"
-      ]
-    }
-  },
-  "required": [
-    "cacheName",
-    "timeToLiveSeconds"
-  ]
+    "required": ["cacheName", "timeToLiveSeconds"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2085

**Description**

clean and validate json schema for v4

need : https://github.com/gravitee-io/gravitee-ui-components/pull/658

Tested with :
https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
https://particles.gravitee.io/?path=/story/components-form-json-schema--string

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-policy-studio-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/2.0.0-policy-studio-SNAPSHOT/gravitee-policy-cache-2.0.0-policy-studio-SNAPSHOT.zip)
  <!-- Version placeholder end -->
