### PR TITLE
chore(deps): update gravitee-parent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.0.0
+    gravitee: gravitee-io/gravitee@4.1.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,20 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    }
-  ]
+    "extends": ["config:base"],
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "chore"
+        }
+    ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["config:base"],
+    "extends": ["config:base", ":label(dependencies)"],
     "rebaseWhen": "conflicted",
     "packageRules": [
         {
@@ -14,6 +14,11 @@
             "matchUpdateTypes": ["patch", "minor"],
             "automerge": true,
             "automergeType": "branch",
+            "semanticCommitType": "chore"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["major"],
             "semanticCommitType": "chore"
         }
     ]

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>5.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.7</gravitee-gateway-api.version>
+        <gravitee-bom.version>6.0.3</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.0.2</version>
     </parent>
 
     <properties>
@@ -43,10 +43,9 @@
         <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
 
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
-        <maven-plugin-prettier.version>0.19</maven-plugin-prettier.version>
-        <maven-plugin-prettier.prettierjava.version>1.6.2</maven-plugin-prettier.prettierjava.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
-<!-- Property used by the publication job in CI-->
+
+        <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
@@ -229,24 +228,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>${maven-plugin-prettier.version}</version>
-                <configuration>
-                    <prettierJavaVersion>${maven-plugin-prettier.prettierjava.version}</prettierJavaVersion>
-                    <skip>${skip.validation}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/CacheAction.java
+++ b/src/main/java/io/gravitee/policy/cache/CacheAction.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/CacheControl.java
+++ b/src/main/java/io/gravitee/policy/cache/CacheControl.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/CachePolicy.java
+++ b/src/main/java/io/gravitee/policy/cache/CachePolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/CacheResponse.java
+++ b/src/main/java/io/gravitee/policy/cache/CacheResponse.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/configuration/CachePolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/cache/configuration/CachePolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/configuration/CacheScope.java
+++ b/src/main/java/io/gravitee/policy/cache/configuration/CacheScope.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/configuration/SerializationMode.java
+++ b/src/main/java/io/gravitee/policy/cache/configuration/SerializationMode.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
+++ b/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/mapper/CacheResponseMapper.java
+++ b/src/main/java/io/gravitee/policy/cache/mapper/CacheResponseMapper.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/resource/CacheElement.java
+++ b/src/main/java/io/gravitee/policy/cache/resource/CacheElement.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/util/CacheControlUtil.java
+++ b/src/main/java/io/gravitee/policy/cache/util/CacheControlUtil.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/cache/util/ExpiresUtil.java
+++ b/src/main/java/io/gravitee/policy/cache/util/ExpiresUtil.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/v3/cache/CachePolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/cache/CachePolicyV3.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/v3/cache/proxy/CacheProxyConnection.java
+++ b/src/main/java/io/gravitee/policy/v3/cache/proxy/CacheProxyConnection.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/v3/cache/proxy/EvaluableProxyResponse.java
+++ b/src/main/java/io/gravitee/policy/v3/cache/proxy/EvaluableProxyResponse.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyV4EmulationEngineIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyV4EmulationEngineIntegrationTest.java
@@ -30,6 +30,7 @@ import io.gravitee.policy.cache.configuration.CachePolicyConfiguration;
 import io.gravitee.policy.v3.cache.CachePolicyV3;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
@@ -63,7 +64,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
 
         final var secondObs = client
             .rxRequest(HttpMethod.GET, "/test")
-            .flatMap(request -> request.rxSend())
+            .flatMap(HttpClientRequest::rxSend)
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
                 return response.toFlowable();
@@ -74,7 +75,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         secondObs
             .assertComplete()
             .assertValue(buffer -> {
-                assertThat(buffer.toString()).isEqualTo(RESPONSE_FROM_BACKEND_1);
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_1);
                 return true;
             })
             .assertNoErrors();
@@ -109,7 +110,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         secondObs
             .assertComplete()
             .assertValue(buffer -> {
-                assertThat(buffer.toString()).isEqualTo(RESPONSE_FROM_BACKEND_2);
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_2);
                 return true;
             })
             .assertNoErrors();
@@ -132,7 +133,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
 
         final var secondObs = client
             .rxRequest(HttpMethod.GET, "/test?cache=" + CacheAction.REFRESH.name())
-            .flatMap(request -> request.rxSend())
+            .flatMap(HttpClientRequest::rxSend)
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
                 return response.toFlowable();
@@ -143,7 +144,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         secondObs
             .assertComplete()
             .assertValue(buffer -> {
-                assertThat(buffer.toString()).isEqualTo(RESPONSE_FROM_BACKEND_2);
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_2);
                 return true;
             })
             .assertNoErrors();
@@ -172,7 +173,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         obs
             .assertComplete()
             .assertValue(buffer -> {
-                assertThat(buffer.toString()).isEqualTo(RESPONSE_FROM_BACKEND_2);
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_2);
                 return true;
             })
             .assertNoErrors();
@@ -192,7 +193,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
 
         final var obs = client
             .rxRequest(HttpMethod.GET, "/test?cache=" + CacheAction.BY_PASS.name())
-            .flatMap(request -> request.rxSend())
+            .flatMap(HttpClientRequest::rxSend)
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
                 return response.toFlowable();
@@ -203,7 +204,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         obs
             .assertComplete()
             .assertValue(buffer -> {
-                assertThat(buffer.toString()).isEqualTo(RESPONSE_FROM_BACKEND_2);
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_2);
                 return true;
             })
             .assertNoErrors();
@@ -218,9 +219,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
 
         final var obs = client
             .rxRequest(HttpMethod.GET, "/test")
-            .flatMap(request -> {
-                return request.rxSend();
-            })
+            .flatMap(HttpClientRequest::rxSend)
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
                 return response.toFlowable();
@@ -231,7 +230,7 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         obs
             .assertComplete()
             .assertValue(buffer -> {
-                assertThat(buffer.toString()).isEqualTo(RESPONSE_FROM_BACKEND_1);
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_1);
                 return true;
             })
             .assertNoErrors();

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyV4IntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/DummyCacheResource.java
+++ b/src/test/java/io/gravitee/policy/cache/DummyCacheResource.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/DummyCacheResource.java
+++ b/src/test/java/io/gravitee/policy/cache/DummyCacheResource.java
@@ -17,16 +17,12 @@ package io.gravitee.policy.cache;
 
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
-import io.gravitee.resource.api.AbstractResource;
-import io.gravitee.resource.api.Resource;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.cache.api.Element;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/src/test/java/io/gravitee/policy/cache/mapper/CacheResponseMapperTest.java
+++ b/src/test/java/io/gravitee/policy/cache/mapper/CacheResponseMapperTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/util/CacheControlUtilTest.java
+++ b/src/test/java/io/gravitee/policy/cache/util/CacheControlUtilTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/util/ExpiresUtilTest.java
+++ b/src/test/java/io/gravitee/policy/cache/util/ExpiresUtilTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/cache/util/ExpiresUtilTest.java
+++ b/src/test/java/io/gravitee/policy/cache/util/ExpiresUtilTest.java
@@ -15,8 +15,9 @@
  */
 package io.gravitee.policy.cache.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Instant;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -28,18 +29,18 @@ public class ExpiresUtilTest {
     @Test
     public void shouldParseExpiresHeader() {
         Instant instant = ExpiresUtil.parseExpires("Thu, 01 Dec 1994 16:00:00 GMT");
-        Assert.assertNotNull(instant);
+        assertThat(instant).isNotNull();
     }
 
     @Test
     public void shouldNotParseExpiresHeader() {
         Instant instant = ExpiresUtil.parseExpires("Thu, 01 Dc 1994 16:00:00 GMT");
-        Assert.assertNull(instant);
+        assertThat(instant).isNull();
     }
 
     @Test
     public void shouldNotParseNullExpiresHeader() {
         Instant instant = ExpiresUtil.parseExpires(null);
-        Assert.assertNull(instant);
+        assertThat(instant).isNull();
     }
 }

--- a/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3IntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3Test.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/io/gravitee/policy/cache/integration/cacheV3.json
+++ b/src/test/resources/io/gravitee/policy/cache/integration/cacheV3.json
@@ -1,55 +1,52 @@
 {
-  "id": "my-api",
-  "name": "my-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/test",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      }
-    ]
-  },
-  "flows": [
-    {
-      "name": "flow-1",
-      "methods": [
-        "GET"
-      ],
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "pre": [
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
         {
-          "name": "Cache",
-          "description": "",
-          "enabled": true,
-          "policy": "cache",
-          "configuration": {
-            "scope": "API",
-            "cacheName": "dummy-cache",
-            "key": "integration-test-cache",
-            "methods": ["GET"]
-          }
+            "name": "flow-1",
+            "methods": ["GET"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Cache",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "cache",
+                    "configuration": {
+                        "scope": "API",
+                        "cacheName": "dummy-cache",
+                        "key": "integration-test-cache",
+                        "methods": ["GET"]
+                    }
+                }
+            ],
+            "post": []
         }
-      ],
-      "post": []
-    }
-  ],
-  "resources": [
-    {
-      "name": "dummy-cache",
-      "enabled": true,
-      "type": "dummy-cache",
-      "configuration": {
-      }
-    }
-  ]
+    ],
+    "resources": [
+        {
+            "name": "dummy-cache",
+            "enabled": true,
+            "type": "dummy-cache",
+            "configuration": {}
+        }
+    ]
 }

--- a/src/test/resources/io/gravitee/policy/cache/integration/cacheV4.json
+++ b/src/test/resources/io/gravitee/policy/cache/integration/cacheV4.json
@@ -1,76 +1,75 @@
 {
-  "id": "apiv4-cache-policy",
-  "name": "apiv4-cache-policy",
-  "description": "apiv4-cache-policy",
-  "definitionVersion": "4.0.0",
-  "type": "proxy",
-  "listeners": [
-    {
-      "type": "http",
-      "paths": [
+    "id": "apiv4-cache-policy",
+    "name": "apiv4-cache-policy",
+    "description": "apiv4-cache-policy",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
         {
-          "path": "/test"
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
         }
-      ],
-      "entrypoints": [
+    ],
+    "endpointGroups": [
         {
-          "type": "http-proxy"
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default-endpoint",
+                    "type": "http-proxy",
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "endpointGroups": [
-    {
-      "name": "default",
-      "type": "http-proxy",
-      "endpoints": [
+    ],
+    "flows": [
         {
-          "name": "default-endpoint",
-          "type": "http-proxy",
-          "configuration": {
-            "target": "http://localhost:8080/endpoint"
-          }
+            "name": "cache-flow",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [
+                {
+                    "name": "Cache",
+                    "description": "test cache policy with V4 API",
+                    "enabled": true,
+                    "policy": "cache",
+                    "configuration": {
+                        "scope": "API",
+                        "cacheName": "dummy-cache",
+                        "key": "integration-test-cache",
+                        "methods": ["GET"]
+                    }
+                }
+            ],
+            "response": [],
+            "subscribe": [],
+            "publish": []
         }
-      ]
-    }
-  ],
-  "flows": [
-    {
-      "name": "cache-flow",
-      "enabled": true,
-      "selectors": [
+    ],
+    "resources": [
         {
-          "type": "http",
-          "path": "/",
-          "pathOperator": "STARTS_WITH"
+            "name": "dummy-cache",
+            "enabled": true,
+            "type": "dummy-cache",
+            "configuration": {}
         }
-      ],
-      "request": [
-        {
-          "name": "Cache",
-          "description": "test cache policy with V4 API",
-          "enabled": true,
-          "policy": "cache",
-          "configuration": {
-            "scope": "API",
-            "cacheName": "dummy-cache",
-            "key": "integration-test-cache",
-            "methods": ["GET"]
-          }
-        }
-      ],
-      "response": [],
-      "subscribe": [],
-      "publish": []
-    }
-  ],
-  "resources": [
-    {
-      "name": "dummy-cache",
-      "enabled": true,
-      "type": "dummy-cache",
-      "configuration": {
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
**Description**

Bump dependencies

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/2.0.0-bump-dependencies-SNAPSHOT/gravitee-policy-cache-2.0.0-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
