### PR TITLE
Correct typo in cache bypass instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ You can use the `cache` policy to cache upstream responses (content, status and 
 
 This policy is based on a _cache resource_, which aligns the underlying cache system with the API lifecycle (stop / start).
 
-Consumers can bypass the cache by adding a `cache=BY_PASS_` query parameter or by providing a `_X-Gravitee-Cache=BY_PASS_` HTTP header.
+Consumers can bypass the cache by adding a `cache=BY_PASS` query parameter or by providing a `X-Gravitee-Cache=BY_PASS` HTTP header.
 
 NOTE: If no cache resource is defined for the policy, or it is not well configured, the API will not be deployed. The resource name is specified in the
 policy configuration `cacheName`, as described below.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2803

**Description**

Correct typo in cache bypass instructions
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-APIM-2803-fix-typo-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/2.0.2-APIM-2803-fix-typo-SNAPSHOT/gravitee-policy-cache-2.0.2-APIM-2803-fix-typo-SNAPSHOT.zip)
  <!-- Version placeholder end -->
