### PR TITLE
fix(cache): deep copy of the mutable headers to avoid problems while async store in cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
-        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.0.0</gravitee-apim.version>
 
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>

--- a/src/test/java/io/gravitee/policy/cache/TransformHeaderPolicy.java
+++ b/src/test/java/io/gravitee/policy/cache/TransformHeaderPolicy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.cache;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class TransformHeaderPolicy implements Policy {
+
+    @Override
+    public String id() {
+        return "transform-headers";
+    }
+
+    @OnResponse
+    public void onResponse(Request request, Response response, PolicyChain policyChain) {
+        execute(request.headers(), response.headers());
+        policyChain.doNext(request, response);
+    }
+
+    @Override
+    public Completable onResponse(HttpExecutionContext ctx) {
+        return Completable.fromAction(() -> execute(ctx.request().headers(), ctx.response().headers())).subscribeOn(Schedulers.single());
+    }
+
+    private void execute(HttpHeaders requestHeaders, HttpHeaders responseHeaders) {
+        if (requestHeaders.contains("X-First-Call")) {
+            // Manipulate header on first call only to simulate a specific behavior happening on headers after the backend response has been cached.
+            responseHeaders.remove("X-Backend-Header");
+            responseHeaders.add("X-Client-Header", "This_Header_Should_Not_Be_Cached");
+        }
+
+        // Add a fingerprint header that can be verified to make sure the policy has been executed.
+        responseHeaders.add("X-Transform-Header-Policy", "Run");
+    }
+}

--- a/src/test/resources/io/gravitee/policy/cache/integration/cacheV3.json
+++ b/src/test/resources/io/gravitee/policy/cache/integration/cacheV3.json
@@ -38,7 +38,15 @@
                     }
                 }
             ],
-            "post": []
+            "post": [
+                {
+                    "name": "Transform headers",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "transform-headers",
+                    "configuration": {}
+                }
+            ]
         }
     ],
     "resources": [

--- a/src/test/resources/io/gravitee/policy/cache/integration/cacheV4.json
+++ b/src/test/resources/io/gravitee/policy/cache/integration/cacheV4.json
@@ -59,7 +59,15 @@
                     }
                 }
             ],
-            "response": [],
+            "response": [
+                {
+                    "name": "Transform headers",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "transform-headers",
+                    "configuration": {}
+                }
+            ],
             "subscribe": [],
             "publish": []
         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4368

**Description**

Response object is mutable. Deep copy of the headers is required to avoid problems while async store in cache

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.3-APIM-4368-deep-copy-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/2.0.3-APIM-4368-deep-copy-headers-SNAPSHOT/gravitee-policy-cache-2.0.3-APIM-4368-deep-copy-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
