### PR TITLE
fix(cache): encode and decode content while storing in cache to allow storing octet-stream data

### DIFF
--- a/src/main/java/io/gravitee/policy/cache/util/ContentTypeUtil.java
+++ b/src/main/java/io/gravitee/policy/cache/util/ContentTypeUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.cache.util;
+
+import io.gravitee.common.http.*;
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.gateway.api.http.*;
+import java.util.*;
+
+/**
+ * @author Wojciech BASZCZYK (wojciech.baszczyk at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ContentTypeUtil {
+
+    private ContentTypeUtil() {}
+
+    public static boolean hasBinaryContentType(HttpHeaders httpHeaders) {
+        if (httpHeaders != null) {
+            MediaType contentTypeMedia = Optional
+                .ofNullable(httpHeaders.get(HttpHeaderNames.CONTENT_TYPE))
+                .map(list -> list.get(0))
+                .map(MediaType::parseMediaType)
+                .orElse(MediaType.MEDIA_ALL);
+            return MediaType.MEDIA_APPLICATION_OCTET_STREAM.equals(contentTypeMedia) || "image".equals(contentTypeMedia.getType());
+        }
+        return false;
+    }
+}

--- a/src/test/java/io/gravitee/policy/cache/DummyCacheResource.java
+++ b/src/test/java/io/gravitee/policy/cache/DummyCacheResource.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.policy.cache;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.policy.cache.configuration.SerializationMode;
+import io.gravitee.policy.cache.mapper.CacheResponseMapper;
+import io.gravitee.policy.cache.resource.CacheElement;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
 import io.gravitee.resource.cache.api.Element;
@@ -31,6 +35,11 @@ import org.junit.jupiter.api.Assertions;
 public class DummyCacheResource extends CacheResource {
 
     private static Cache instance;
+    private static CacheResponseMapper mapper = new CacheResponseMapper();
+
+    static {
+        mapper.setSerializationMode(SerializationMode.TEXT);
+    }
 
     @Override
     public Cache getCache(ExecutionContext executionContext) {
@@ -53,6 +62,11 @@ public class DummyCacheResource extends CacheResource {
             Thread.sleep(2000);
         } catch (Exception e) {}
         Assertions.assertEquals(expectedSize, ((Map) getDummyCacheInstance().getNativeCache()).size());
+    }
+
+    public static CacheResponse getFirstEntry() throws JsonProcessingException {
+        CacheElement cacheElement = (CacheElement) ((Map) getDummyCacheInstance().getNativeCache()).values().iterator().next();
+        return mapper.readValue(cacheElement.value().toString(), CacheResponse.class);
     }
 
     @Override


### PR DESCRIPTION

**Issue**

https://gravitee.atlassian.net/browse/APIM-4074

**Description**

encode and decode content while storing in cache to allow storing octet-stream data

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.4-APIM-4074-cache-images-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/2.0.4-APIM-4074-cache-images-SNAPSHOT/gravitee-policy-cache-2.0.4-APIM-4074-cache-images-SNAPSHOT.zip)
  <!-- Version placeholder end -->
