### PR TITLE
feat(cache-policy): use async Cache API (APIM-13557)

### DIFF
--- a/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
+++ b/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
@@ -84,55 +84,55 @@ public class CacheInvoker implements Invoker {
         var cacheId = hash(executionContext);
         log.debug("Looking for element in cache with the key {}", cacheId);
 
-        return Single.<Optional<Element>>create(emitter ->
-            cache
-                .getAsync(cacheId)
-                .onComplete(ar -> {
-                    if (ar.succeeded()) {
-                        emitter.onSuccess(Optional.ofNullable(ar.result()));
+        return Single.fromCompletionStage(cache.getAsync(cacheId).map(Optional::ofNullable).toCompletionStage()).flatMapCompletable(
+            optElt -> {
+                Response response = executionContext.response();
+                if (optElt.isEmpty() || action == CacheAction.REFRESH) {
+                    if (action == CacheAction.REFRESH) {
+                        log.info(
+                            "A refresh action has been received for key {}, invoke backend with invoker {}",
+                            cacheId,
+                            this.delegateInvoker.getClass().getName()
+                        );
                     } else {
-                        emitter.onError(ar.cause());
+                        log.debug(
+                            "No element for key {}, invoke backend with invoker {}",
+                            cacheId,
+                            this.delegateInvoker.getClass().getName()
+                        );
                     }
-                })
-        ).flatMapCompletable(optElt -> {
-            Response response = executionContext.response();
-            if (optElt.isEmpty() || action == CacheAction.REFRESH) {
-                if (action == CacheAction.REFRESH) {
-                    log.info(
-                        "A refresh action has been received for key {}, invoke backend with invoker {}",
-                        cacheId,
-                        this.delegateInvoker.getClass().getName()
+
+                    return this.delegateInvoker.invoke(executionContext).andThen(
+                        storeInCacheEvaluation(executionContext, cacheId, response)
                     );
                 } else {
-                    log.debug("No element for key {}, invoke backend with invoker {}", cacheId, this.delegateInvoker.getClass().getName());
-                }
+                    log.debug("An element has been found for key {}, returning the cached response to the initial client", cacheId);
 
-                return this.delegateInvoker.invoke(executionContext).andThen(storeInCacheEvaluation(executionContext, cacheId, response));
-            } else {
-                log.debug("An element has been found for key {}, returning the cached response to the initial client", cacheId);
-
-                var elt = optElt.get();
-                try {
-                    var cacheResponse = mapper.readValue(elt.value().toString(), CacheResponse.class);
-                    response.status(cacheResponse.getStatus());
-                    if (cacheResponse.getHeaders() != null) {
-                        cacheResponse.getHeaders().forEach((key, values) -> values.forEach(value -> response.headers().add(key, value)));
+                    var elt = optElt.get();
+                    try {
+                        var cacheResponse = mapper.readValue(elt.value().toString(), CacheResponse.class);
+                        response.status(cacheResponse.getStatus());
+                        if (cacheResponse.getHeaders() != null) {
+                            cacheResponse
+                                .getHeaders()
+                                .forEach((key, values) -> values.forEach(value -> response.headers().add(key, value)));
+                        }
+                        Buffer content = hasBinaryContentType(cacheResponse.getHeaders())
+                            ? Buffer.buffer(Base64.getDecoder().decode(cacheResponse.getContent().getBytes()))
+                            : cacheResponse.getContent();
+                        return response.onBody(body -> body.ignoreElement().andThen(Maybe.just(content)));
+                    } catch (JsonProcessingException e) {
+                        log.warn(
+                            "Cannot deserialize element with key {}, invoke backend with invoker {}",
+                            cacheId,
+                            delegateInvoker.getClass().getName()
+                        );
+                        evictFromCache(cacheId);
+                        return this.delegateInvoker.invoke(executionContext);
                     }
-                    Buffer content = hasBinaryContentType(cacheResponse.getHeaders())
-                        ? Buffer.buffer(Base64.getDecoder().decode(cacheResponse.getContent().getBytes()))
-                        : cacheResponse.getContent();
-                    return response.onBody(body -> body.ignoreElement().andThen(Maybe.just(content)));
-                } catch (JsonProcessingException e) {
-                    log.warn(
-                        "Cannot deserialize element with key {}, invoke backend with invoker {}",
-                        cacheId,
-                        delegateInvoker.getClass().getName()
-                    );
-                    evictFromCache(cacheId);
-                    return this.delegateInvoker.invoke(executionContext);
                 }
             }
-        });
+        );
     }
 
     private Completable storeInCacheEvaluation(ExecutionContext executionContext, String cacheId, Response response) {
@@ -171,17 +171,7 @@ public class CacheInvoker implements Invoker {
     }
 
     private void evictFromCache(String cacheId) {
-        Completable.create(emitter ->
-            cache
-                .evictAsync(cacheId)
-                .onComplete(ar -> {
-                    if (ar.succeeded()) {
-                        emitter.onComplete();
-                    } else {
-                        emitter.onError(ar.cause());
-                    }
-                })
-        )
+        Completable.fromCompletionStage(cache.evictAsync(cacheId).toCompletionStage())
             .doOnComplete(() -> log.debug("Element {} evicted from the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be evicted from the cache {}", cacheId, cache.getName(), err);
@@ -201,17 +191,7 @@ public class CacheInvoker implements Invoker {
             long timeToLive = resolveTimeToLive(httpHeaders);
             CacheElement element = new CacheElement(cacheId, mapper.writeValueAsString(resp));
             element.setTimeToLive((int) timeToLive);
-            return Completable.create(emitter ->
-                cache
-                    .putAsync(element)
-                    .onComplete(ar -> {
-                        if (ar.succeeded()) {
-                            emitter.onComplete();
-                        } else {
-                            emitter.onError(ar.cause());
-                        }
-                    })
-            );
+            return Completable.fromCompletionStage(cache.putAsync(element).toCompletionStage());
         })
             .doOnComplete(() -> log.debug("Element {} stored into the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {

--- a/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
+++ b/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
@@ -36,10 +36,10 @@ import io.gravitee.policy.cache.util.ExpiresUtil;
 import io.gravitee.resource.api.ResourceManager;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
+import io.gravitee.resource.cache.api.Element;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Collections;
@@ -84,55 +84,55 @@ public class CacheInvoker implements Invoker {
         var cacheId = hash(executionContext);
         log.debug("Looking for element in cache with the key {}", cacheId);
 
-        return Single.fromCallable(() -> Optional.ofNullable(cache.get(cacheId)))
-            .subscribeOn(Schedulers.io())
-            .flatMapCompletable(optElt -> {
-                Response response = executionContext.response();
-                if (optElt.isEmpty() || action == CacheAction.REFRESH) {
-                    if (action == CacheAction.REFRESH) {
-                        log.info(
-                            "A refresh action has been received for key {}, invoke backend with invoker {}",
-                            cacheId,
-                            this.delegateInvoker.getClass().getName()
-                        );
+        return Single.<Optional<Element>>create(emitter ->
+            cache
+                .getAsync(cacheId)
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        emitter.onSuccess(Optional.ofNullable(ar.result()));
                     } else {
-                        log.debug(
-                            "No element for key {}, invoke backend with invoker {}",
-                            cacheId,
-                            this.delegateInvoker.getClass().getName()
-                        );
+                        emitter.onError(ar.cause());
                     }
-
-                    return this.delegateInvoker.invoke(executionContext).andThen(
-                        storeInCacheEvaluation(executionContext, cacheId, response)
+                })
+        ).flatMapCompletable(optElt -> {
+            Response response = executionContext.response();
+            if (optElt.isEmpty() || action == CacheAction.REFRESH) {
+                if (action == CacheAction.REFRESH) {
+                    log.info(
+                        "A refresh action has been received for key {}, invoke backend with invoker {}",
+                        cacheId,
+                        this.delegateInvoker.getClass().getName()
                     );
                 } else {
-                    log.debug("An element has been found for key {}, returning the cached response to the initial client", cacheId);
-
-                    var elt = optElt.get();
-                    try {
-                        var cacheResponse = mapper.readValue(elt.value().toString(), CacheResponse.class);
-                        response.status(cacheResponse.getStatus());
-                        if (cacheResponse.getHeaders() != null) {
-                            cacheResponse
-                                .getHeaders()
-                                .forEach((key, values) -> values.forEach(value -> response.headers().add(key, value)));
-                        }
-                        Buffer content = hasBinaryContentType(cacheResponse.getHeaders())
-                            ? Buffer.buffer(Base64.getDecoder().decode(cacheResponse.getContent().getBytes()))
-                            : cacheResponse.getContent();
-                        return response.onBody(body -> body.ignoreElement().andThen(Maybe.just(content)));
-                    } catch (JsonProcessingException e) {
-                        log.warn(
-                            "Cannot deserialize element with key {}, invoke backend with invoker {}",
-                            cacheId,
-                            delegateInvoker.getClass().getName()
-                        );
-                        evictFromCache(cacheId);
-                        return this.delegateInvoker.invoke(executionContext);
-                    }
+                    log.debug("No element for key {}, invoke backend with invoker {}", cacheId, this.delegateInvoker.getClass().getName());
                 }
-            });
+
+                return this.delegateInvoker.invoke(executionContext).andThen(storeInCacheEvaluation(executionContext, cacheId, response));
+            } else {
+                log.debug("An element has been found for key {}, returning the cached response to the initial client", cacheId);
+
+                var elt = optElt.get();
+                try {
+                    var cacheResponse = mapper.readValue(elt.value().toString(), CacheResponse.class);
+                    response.status(cacheResponse.getStatus());
+                    if (cacheResponse.getHeaders() != null) {
+                        cacheResponse.getHeaders().forEach((key, values) -> values.forEach(value -> response.headers().add(key, value)));
+                    }
+                    Buffer content = hasBinaryContentType(cacheResponse.getHeaders())
+                        ? Buffer.buffer(Base64.getDecoder().decode(cacheResponse.getContent().getBytes()))
+                        : cacheResponse.getContent();
+                    return response.onBody(body -> body.ignoreElement().andThen(Maybe.just(content)));
+                } catch (JsonProcessingException e) {
+                    log.warn(
+                        "Cannot deserialize element with key {}, invoke backend with invoker {}",
+                        cacheId,
+                        delegateInvoker.getClass().getName()
+                    );
+                    evictFromCache(cacheId);
+                    return this.delegateInvoker.invoke(executionContext);
+                }
+            }
+        });
     }
 
     private Completable storeInCacheEvaluation(ExecutionContext executionContext, String cacheId, Response response) {
@@ -171,8 +171,17 @@ public class CacheInvoker implements Invoker {
     }
 
     private void evictFromCache(String cacheId) {
-        Completable.fromAction(() -> cache.evict(cacheId))
-            .subscribeOn(Schedulers.io())
+        Completable.create(emitter ->
+            cache
+                .evictAsync(cacheId)
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        emitter.onComplete();
+                    } else {
+                        emitter.onError(ar.cause());
+                    }
+                })
+        )
             .doOnComplete(() -> log.debug("Element {} evicted from the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be evicted from the cache {}", cacheId, cache.getName(), err);
@@ -182,7 +191,7 @@ public class CacheInvoker implements Invoker {
     }
 
     private void storeInCache(String cacheId, HttpHeaders httpHeaders, int status, Buffer buffer) {
-        Completable.fromAction(() -> {
+        Completable.defer(() -> {
             final var resp = new CacheResponse();
             Buffer content = hasBinaryContentType(httpHeaders) ? Buffer.buffer(Base64.getEncoder().encode(buffer.getBytes())) : buffer;
             resp.setContent(content);
@@ -192,9 +201,18 @@ public class CacheInvoker implements Invoker {
             long timeToLive = resolveTimeToLive(httpHeaders);
             CacheElement element = new CacheElement(cacheId, mapper.writeValueAsString(resp));
             element.setTimeToLive((int) timeToLive);
-            cache.put(element);
+            return Completable.create(emitter ->
+                cache
+                    .putAsync(element)
+                    .onComplete(ar -> {
+                        if (ar.succeeded()) {
+                            emitter.onComplete();
+                        } else {
+                            emitter.onError(ar.cause());
+                        }
+                    })
+            );
         })
-            .subscribeOn(Schedulers.io())
             .doOnComplete(() -> log.debug("Element {} stored into the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be stored into the cache {}", cacheId, cache.getName(), err);


### PR DESCRIPTION
## Summary
- Replace blocking `cache.get/put/evict` + `Schedulers.io()` with async `cache.getAsync/putAsync/evictAsync` (Vert.x Future) bridged to RxJava in `CacheInvoker.java`
- Removes `Schedulers.io()` thread pool dependency — cache operations now run on the Vert.x event loop when backed by an async cache resource (e.g. Redis)
- No changes to `CachePolicyV3.java` (legacy v2 path keeps `vertx.executeBlocking`)

## Test plan
- [x] All 58 existing tests pass (unit + integration)
- [ ] Deploy with Redis cache resource and verify cache hit/miss/evict behavior
- [ ] Verify no `Schedulers.io()` thread pool usage in thread dumps

Fixes APIM-13557