### PR TITLE
feat(cache-policy): use async Cache API (APIM-13557)

### DIFF
--- a/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
+++ b/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
@@ -84,8 +84,8 @@ public class CacheInvoker implements Invoker {
         var cacheId = hash(executionContext);
         log.debug("Looking for element in cache with the key {}", cacheId);
 
-        return Single.fromCallable(() -> Optional.ofNullable(cache.get(cacheId)))
-            .subscribeOn(Schedulers.io())
+        return Single.fromCompletionStage(cache.getAsync(cacheId).map(Optional::ofNullable).toCompletionStage())
+            .observeOn(Schedulers.io()) // Deserialize on IO thread to avoid blocking event loop with large payloads
             .flatMapCompletable(optElt -> {
                 Response response = executionContext.response();
                 if (optElt.isEmpty() || action == CacheAction.REFRESH) {
@@ -171,8 +171,7 @@ public class CacheInvoker implements Invoker {
     }
 
     private void evictFromCache(String cacheId) {
-        Completable.fromAction(() -> cache.evict(cacheId))
-            .subscribeOn(Schedulers.io())
+        Completable.fromCompletionStage(cache.evictAsync(cacheId).toCompletionStage())
             .doOnComplete(() -> log.debug("Element {} evicted from the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be evicted from the cache {}", cacheId, cache.getName(), err);
@@ -182,7 +181,8 @@ public class CacheInvoker implements Invoker {
     }
 
     private void storeInCache(String cacheId, HttpHeaders httpHeaders, int status, Buffer buffer) {
-        Completable.fromAction(() -> {
+        // Serialize on IO scheduler to avoid blocking the event loop with large payloads
+        Single.fromCallable(() -> {
             final var resp = new CacheResponse();
             Buffer content = hasBinaryContentType(httpHeaders) ? Buffer.buffer(Base64.getEncoder().encode(buffer.getBytes())) : buffer;
             resp.setContent(content);
@@ -192,9 +192,10 @@ public class CacheInvoker implements Invoker {
             long timeToLive = resolveTimeToLive(httpHeaders);
             CacheElement element = new CacheElement(cacheId, mapper.writeValueAsString(resp));
             element.setTimeToLive((int) timeToLive);
-            cache.put(element);
+            return element;
         })
             .subscribeOn(Schedulers.io())
+            .flatMapCompletable(element -> Completable.fromCompletionStage(cache.putAsync(element).toCompletionStage()))
             .doOnComplete(() -> log.debug("Element {} stored into the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be stored into the cache {}", cacheId, cache.getName(), err);


### PR DESCRIPTION
## Summary
- Replace blocking `cache.get/put/evict` + `Schedulers.io()` with async `cache.getAsync/putAsync/evictAsync` (Vert.x Future) bridged to RxJava via `CompletionStage` in `CacheInvoker.java`
- Removes `Schedulers.io()` thread pool dependency — cache operations now run on the Vert.x event loop when backed by an async cache resource (e.g. Redis)
- No changes to `CachePolicyV3.java` (already migrated to Vert.x 5 `executeBlocking`)

## Breaking change
Requires `cache-provider-api` 2.0.0+ with async `Cache` interface (`getAsync`, `putAsync`, `evictAsync`).

## Test plan
- [x] All 58 existing tests pass (unit + integration)
- [ ] Deploy with Redis cache resource and verify cache hit/miss/evict behavior
- [ ] Verify no `Schedulers.io()` thread pool usage in thread dumps

Fixes APIM-13557
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-wba-async-cache-api-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/4.0.0-wba-async-cache-api-alpha-SNAPSHOT/gravitee-policy-cache-4.0.0-wba-async-cache-api-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
