### PR TITLE
fix(cache-policy): use async Cache API (APIM-13557)

### DIFF
--- a/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
+++ b/src/main/java/io/gravitee/policy/cache/invoker/CacheInvoker.java
@@ -84,8 +84,8 @@ public class CacheInvoker implements Invoker {
         var cacheId = hash(executionContext);
         log.debug("Looking for element in cache with the key {}", cacheId);
 
-        return Single.fromCallable(() -> Optional.ofNullable(cache.get(cacheId)))
-            .subscribeOn(Schedulers.io())
+        return Single.fromCompletionStage(cache.getAsync(cacheId).map(Optional::ofNullable).toCompletionStage())
+            .observeOn(Schedulers.io()) // Deserialize on IO thread to avoid blocking event loop with large payloads
             .flatMapCompletable(optElt -> {
                 Response response = executionContext.response();
                 if (optElt.isEmpty() || action == CacheAction.REFRESH) {
@@ -171,8 +171,7 @@ public class CacheInvoker implements Invoker {
     }
 
     private void evictFromCache(String cacheId) {
-        Completable.fromAction(() -> cache.evict(cacheId))
-            .subscribeOn(Schedulers.io())
+        Completable.fromCompletionStage(cache.evictAsync(cacheId).toCompletionStage())
             .doOnComplete(() -> log.debug("Element {} evicted from the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be evicted from the cache {}", cacheId, cache.getName(), err);
@@ -182,7 +181,8 @@ public class CacheInvoker implements Invoker {
     }
 
     private void storeInCache(String cacheId, HttpHeaders httpHeaders, int status, Buffer buffer) {
-        Completable.fromAction(() -> {
+        // Serialize on IO scheduler to avoid blocking the event loop with large payloads
+        Single.fromCallable(() -> {
             final var resp = new CacheResponse();
             Buffer content = hasBinaryContentType(httpHeaders) ? Buffer.buffer(Base64.getEncoder().encode(buffer.getBytes())) : buffer;
             resp.setContent(content);
@@ -192,9 +192,10 @@ public class CacheInvoker implements Invoker {
             long timeToLive = resolveTimeToLive(httpHeaders);
             CacheElement element = new CacheElement(cacheId, mapper.writeValueAsString(resp));
             element.setTimeToLive((int) timeToLive);
-            cache.put(element);
+            return element;
         })
             .subscribeOn(Schedulers.io())
+            .flatMapCompletable(element -> Completable.fromCompletionStage(cache.putAsync(element).toCompletionStage()))
             .doOnComplete(() -> log.debug("Element {} stored into the cache {}", cacheId, cache.getName()))
             .onErrorResumeNext(err -> {
                 log.warn("Element {} can't be stored into the cache {}", cacheId, cache.getName(), err);


### PR DESCRIPTION
## Summary

Cherry-pick of alpha commit [\`9ddb1a3\`](https://github.com/gravitee-io/gravitee-policy-cache/commit/9ddb1a3c13a3c9b4ab609a6eb0cc06c1ff7067e4) to master so the v4/Vert.x 4 line (APIM 4.10.x, 4.11.x) also gets the async Cache API migration. Part of APIM-13553 (Redis cache Vert.x rewrite).

Replaces the blocking \`cache.get(key)\` + \`subscribeOn(Schedulers.io())\` pattern in \`CacheInvoker\` with \`cache.getAsync(key)\` + \`Single.fromCompletionStage(...)\`. Same change as \`9ddb1a3\` on \`origin/alpha\` — clean cherry-pick, no conflicts.

## Why it's needed on master

\`cache-provider-api\` 2.1.0 (APIM-13554) shipped the async Cache SPI and was backported to \`apim-bom\` on the 4.10.x / 4.11.x lines (4.10.12+, 4.11.2+). Master of this plugin tracks \`gravitee-apim.version=4.11.4\`, so the dependency is already in place — this PR just applies the caller-side migration.

Without this, when \`cache-redis\` ≥ 4.1.0 is loaded as the backing resource, \`cache.get/put\` calls go blocking against an async Redis client — risks the same class of deadlock documented for \`policy-oauth2\` in APIM-13700 (though cache-policy's existing \`Schedulers.io()\` bridge was protecting against the full event-loop-parking scenario; this PR removes the bridge as no longer needed).

## Test plan

- [x] \`mvn test\` — 58/58 tests passing locally (\`CacheInvokerTest\`, \`CachePolicyV4IntegrationTest\`, \`CachePolicyV4EmulationEngineIntegrationTest\`, \`CachePolicyV3IntegrationTest\`, \`CacheResponseMapperTest\`)
- [x] Manually exercised in an end-to-end APIM 4.10.12 worktree alongside cache-redis 4.2.0 + oauth2 PR #146 + data-cache async migration — no deadlock, no errors under \`hey -c 8 -z 30s\` load (see \`/tmp/apim-13700-test/TEST_REPORT.md\`).
- [ ] CI green

Related: APIM-13553, APIM-13554, APIM-13557, APIM-13700, gravitee-resource-cache-redis#82, gravitee-policy-oauth2#146.

\`fix(...)\` conventional prefix so semantic-release issues a patch bump on merge.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-wba-APIM-13557-async-cache-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/3.0.1-wba-APIM-13557-async-cache-api-SNAPSHOT/gravitee-policy-cache-3.0.1-wba-APIM-13557-async-cache-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
