### PR TITLE
fix: add allowRefreshAction toggle to restrict client-triggered cache resets

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,16 @@ You can use the `cache` policy to cache upstream responses (content, status and 
 
 This policy is based on a _cache resource_, which aligns the underlying cache system with the API lifecycle (stop / start).
 
-Consumers can bypass the cache by adding a `cache=BY_PASS` query parameter or by providing a `X-Gravitee-Cache=BY_PASS` HTTP header.
+Consumers can influence cache behaviour at request time using the `X-Gravitee-Cache` HTTP header or the `?cache=` query parameter:
+
+* `BY_PASS`: skips the cache entirely and forwards the request directly to the backend. The response is *not* stored. +
+  Example: `X-Gravitee-Cache: BY_PASS` or `?cache=BY_PASS`
+* `REFRESH`: ignores any existing cached entry, re-invokes the backend, and overwrites the cache with the fresh response. +
+  Example: `X-Gravitee-Cache: REFRESH` or `?cache=REFRESH`
+
+WARNING: The `REFRESH` action allows any client to force a cache reset on demand, which can cause unexpected upstream load and facilitate cache poisoning. Use the `allowRefreshAction` configuration option to disable it for public APIs.
+
+NOTE: `allowRefreshAction` defaults to `true` for backward compatibility. It is strongly recommended to explicitly set `allowRefreshAction: false` for public APIs unless clients have a legitimate need to trigger cache refreshes.
 
 NOTE: If no cache resource is defined for the policy, or it is not well configured, the API will not be deployed. The resource name is specified in the
 policy configuration `cacheName`, as described below.
@@ -52,6 +61,7 @@ You can configure the policy with the following options:
 |responseCondition||Add an extra condition (with Expression Language) based on the response to activate cache. For example use `{#upstreamResponse.status == 200}` to only cache 200 responses status. By default, all 2xx are cached.|string|
 |useResponseCacheHeaders||Time to live based on 'Cache-Control' and / or 'Expires' headers from backend response|boolean|false
 |scope|X|Cached response can be set for a single consumer (application) or for all applications.<br><strong>WARNING:</strong> Please be aware that by using an \"API\" scope, data will be shared between all consumers !|API / APPLICATION|APPLICATION
+|allowRefreshAction||When disabled, `REFRESH` requests from clients are silently ignored and treated as normal cache lookups. Disable to prevent unauthorized cache resets.|boolean|true
 
 |===
 
@@ -93,7 +103,8 @@ TIP: To learn more about the Gravitee Expression Language, see the *API Publishe
     "useResponseCacheHeaders": false,
     "scope": "APPLICATION",
     "methods": ["POST"],
-    "responseCondition": "{#upstreamResponse.status == 201}"
+    "responseCondition": "{#upstreamResponse.status == 201}",
+    "allowRefreshAction": false
 }
 ----
 

--- a/src/main/java/io/gravitee/policy/cache/CachePolicy.java
+++ b/src/main/java/io/gravitee/policy/cache/CachePolicy.java
@@ -28,6 +28,7 @@ import io.gravitee.policy.cache.configuration.SerializationMode;
 import io.gravitee.policy.cache.invoker.CacheInvoker;
 import io.gravitee.policy.v3.cache.CachePolicyV3;
 import io.gravitee.resource.api.ResourceManager;
+import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
 import io.reactivex.rxjava3.core.Completable;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +52,12 @@ public class CachePolicy extends CachePolicyV3 implements Policy {
     public Completable onRequest(HttpExecutionContext ctx) {
         setMapperSerializationMode(ctx);
 
-        action = lookForAction(ctx.request());
+        CacheAction action = lookForAction(ctx.request());
+
+        if (action == CacheAction.REFRESH && !cachePolicyConfiguration.isAllowRefreshAction()) {
+            log.debug("REFRESH action is disabled by policy configuration, ignoring for request {}", ctx.request().id());
+            action = null;
+        }
 
         if (action != CacheAction.BY_PASS) {
             if (isCachedMethod(ctx.request().method())) {
@@ -66,7 +72,7 @@ public class CachePolicy extends CachePolicyV3 implements Policy {
                     );
                 }
 
-                cache = cacheResource.getCache(ctx);
+                Cache cache = cacheResource.getCache(ctx);
                 if (cache == null) {
                     return ctx.interruptWith(
                         new ExecutionFailure(HttpStatusCode.INTERNAL_SERVER_ERROR_500).message(

--- a/src/main/java/io/gravitee/policy/cache/configuration/CachePolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/cache/configuration/CachePolicyConfiguration.java
@@ -43,6 +43,8 @@ public class CachePolicyConfiguration implements PolicyConfiguration {
 
     private boolean useResponseCacheHeaders = false;
 
+    private boolean allowRefreshAction = true;
+
     public String getCacheName() {
         return cacheName;
     }
@@ -97,5 +99,13 @@ public class CachePolicyConfiguration implements PolicyConfiguration {
 
     public void setResponseCondition(String responseCondition) {
         this.responseCondition = responseCondition;
+    }
+
+    public boolean isAllowRefreshAction() {
+        return allowRefreshAction;
+    }
+
+    public void setAllowRefreshAction(boolean allowRefreshAction) {
+        this.allowRefreshAction = allowRefreshAction;
     }
 }

--- a/src/main/java/io/gravitee/policy/v3/cache/CachePolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/cache/CachePolicyV3.java
@@ -95,6 +95,11 @@ public class CachePolicyV3 {
 
         action = lookForAction(request);
 
+        if (action == CacheAction.REFRESH && !cachePolicyConfiguration.isAllowRefreshAction()) {
+            log.debug("REFRESH action is disabled by policy configuration, ignoring for request {}", request.id());
+            action = null;
+        }
+
         if (action != CacheAction.BY_PASS) {
             if (isCachedMethod(request.method())) {
                 // It's safe to do so because a new instance of policy is created for each request.

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -74,6 +74,12 @@
                     "text": "Cached response can be set for a single consumer (application) or for all consumers.<br><strong>WARNING:</strong> Please be aware that by using an \"API\" scope, data will be shared between all consumers!"
                 }
             }
+        },
+        "allowRefreshAction": {
+            "title": "Allow REFRESH action",
+            "description": "Allow clients to force a cache refresh via 'X-Gravitee-Cache: REFRESH' or '?cache=REFRESH'. Disable for public APIs to prevent unauthorized cache resets.",
+            "type": "boolean",
+            "default": true
         }
     },
     "required": ["cacheName", "timeToLiveSeconds"]

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyTest.java
@@ -27,6 +27,7 @@ import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
 import io.gravitee.policy.cache.configuration.CachePolicyConfiguration;
 import io.gravitee.policy.cache.invoker.CacheInvoker;
+import io.gravitee.policy.v3.cache.CachePolicyV3;
 import io.gravitee.resource.api.ResourceManager;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
@@ -158,6 +159,31 @@ public class CachePolicyTest {
 
         verify(httpExecutionContext, never()).interruptWith(any());
         verify(httpExecutionContext, never()).setInternalAttribute(
+            eq(InternalContextAttributes.ATTR_INTERNAL_INVOKER),
+            any(CacheInvoker.class)
+        );
+    }
+
+    @Test
+    public void shouldIgnoreRefreshAction_WhenRefreshActionDisabled() {
+        when(request.headers()).thenReturn(
+            io.gravitee.gateway.api.http.HttpHeaders.create().add(CachePolicyV3.X_GRAVITEE_CACHE_ACTION, CacheAction.REFRESH.name())
+        );
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(httpExecutionContext.request()).thenReturn(request);
+        when(cachePolicyConfiguration.isAllowRefreshAction()).thenReturn(false);
+        ResourceManager rm = mock(ResourceManager.class);
+        CacheResource cr = mock(CacheResource.class);
+        Cache cache = mock(Cache.class);
+        when(httpExecutionContext.getComponent(ResourceManager.class)).thenReturn(rm);
+        when(rm.getResource(any(), eq(CacheResource.class))).thenReturn(cr);
+        when(cr.getCache(httpExecutionContext)).thenReturn(cache);
+
+        CachePolicy cachePolicy = new CachePolicy(cachePolicyConfiguration);
+        cachePolicy.onRequest(httpExecutionContext);
+
+        verify(httpExecutionContext, never()).interruptWith(any());
+        verify(httpExecutionContext, times(1)).setInternalAttribute(
             eq(InternalContextAttributes.ATTR_INTERNAL_INVOKER),
             any(CacheInvoker.class)
         );

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyV4EmulationEngineIntegrationTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
-@DeployApi("/io/gravitee/policy/cache/integration/cacheV3.json")
+@DeployApi({ "/io/gravitee/policy/cache/integration/cacheV3.json", "/io/gravitee/policy/cache/integration/cacheV3RefreshDisabled.json" })
 public abstract class CachePolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTest<CachePolicyV3, CachePolicyConfiguration> {
 
     public static final String RESPONSE_FROM_BACKEND_1 = "response from backend";
@@ -409,6 +409,59 @@ public abstract class CachePolicyV4EmulationEngineIntegrationTest extends Abstra
         // We should have called the backend twice
         wiremock.verify(2, getRequestedFor(urlPathEqualTo("/endpoint")));
         DummyCacheResource.checkNumberOfCacheEntries(0);
+    }
+
+    @Test
+    @DisplayName("Should NOT refresh cache when allowRefreshAction is disabled")
+    void shouldNotRefreshCache_WhenRefreshActionDisabled(HttpClient client) throws Exception {
+        wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND_1)));
+
+        final var firstObs = client
+            .rxRequest(HttpMethod.GET, "/test-refresh-disabled")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test();
+
+        firstObs.await(1000, TimeUnit.MILLISECONDS);
+        firstObs
+            .assertComplete()
+            .assertValue(buffer -> {
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_1);
+                return true;
+            })
+            .assertNoErrors();
+
+        DummyCacheResource.checkNumberOfCacheEntries(1);
+
+        wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND_2)));
+
+        final var secondObs = client
+            .rxRequest(HttpMethod.GET, "/test-refresh-disabled")
+            .flatMap(request -> request.putHeader(CachePolicyV3.X_GRAVITEE_CACHE_ACTION, CacheAction.REFRESH.name()).rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test();
+
+        secondObs.await(1000, TimeUnit.MILLISECONDS);
+        secondObs
+            .assertComplete()
+            .assertValue(buffer -> {
+                assertThat(buffer).hasToString(RESPONSE_FROM_BACKEND_1);
+                return true;
+            })
+            .assertNoErrors();
+
+        // REFRESH was suppressed: backend called only once
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        DummyCacheResource.checkNumberOfCacheEntries(1);
+        CacheResponse firstEntry = DummyCacheResource.getFirstEntry();
+        assertThat(firstEntry).isNotNull();
+        assertThat(firstEntry.getContent()).hasToString(RESPONSE_FROM_BACKEND_1);
     }
 
     private void performFirstCall(HttpClient client) throws InterruptedException {

--- a/src/test/java/io/gravitee/policy/cache/CachePolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/cache/CachePolicyV4IntegrationTest.java
@@ -25,7 +25,11 @@ import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFact
 import java.util.Map;
 
 @DeployApi(
-    { "/io/gravitee/policy/cache/integration/cacheV4.json", "/io/gravitee/policy/cache/integration/cacheV4NoResponseCondition.json" }
+    {
+        "/io/gravitee/policy/cache/integration/cacheV4.json",
+        "/io/gravitee/policy/cache/integration/cacheV4NoResponseCondition.json",
+        "/io/gravitee/policy/cache/integration/cacheV4RefreshDisabled.json",
+    }
 )
 public class CachePolicyV4IntegrationTest extends CachePolicyV4EmulationEngineIntegrationTest {
 

--- a/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3IntegrationTest.java
@@ -26,6 +26,10 @@ import io.gravitee.policy.cache.CachePolicyV4EmulationEngineIntegrationTest;
  */
 @GatewayTest(v2ExecutionMode = ExecutionMode.V3)
 @DeployApi(
-    { "/io/gravitee/policy/cache/integration/cacheV3.json", "/io/gravitee/policy/cache/integration/cacheV3NoResponseCondition.json" }
+    {
+        "/io/gravitee/policy/cache/integration/cacheV3.json",
+        "/io/gravitee/policy/cache/integration/cacheV3NoResponseCondition.json",
+        "/io/gravitee/policy/cache/integration/cacheV3RefreshDisabled.json",
+    }
 )
 class CachePolicyV3IntegrationTest extends CachePolicyV4EmulationEngineIntegrationTest {}

--- a/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/cache/CachePolicyV3Test.java
@@ -30,6 +30,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.cache.CacheAction;
 import io.gravitee.policy.cache.configuration.CachePolicyConfiguration;
 import io.gravitee.policy.cache.configuration.CacheScope;
 import io.gravitee.resource.api.ResourceManager;
@@ -201,6 +202,26 @@ public class CachePolicyV3Test {
         verify(policyChain, times(1)).doNext(any(), any());
         verify(policyChain, never()).failWith(any());
         verify(executionContext, never()).setAttribute(eq(ExecutionContext.ATTR_INVOKER), any(CachePolicyV3.CacheInvoker.class));
+    }
+
+    @Test
+    public void shouldIgnoreRefreshAction_WhenRefreshActionDisabled() {
+        when(request.headers()).thenReturn(HttpHeaders.create().add(CachePolicyV3.X_GRAVITEE_CACHE_ACTION, CacheAction.REFRESH.name()));
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(cachePolicyConfiguration.isAllowRefreshAction()).thenReturn(false);
+        ResourceManager rm = mock(ResourceManager.class);
+        CacheResource cr = mock(CacheResource.class);
+        Cache cache = mock(Cache.class);
+        when(executionContext.getComponent(ResourceManager.class)).thenReturn(rm);
+        when(rm.getResource(any(), eq(CacheResource.class))).thenReturn(cr);
+        when(cr.getCache(executionContext)).thenReturn(cache);
+
+        CachePolicyV3 cachePolicyV3 = new CachePolicyV3(cachePolicyConfiguration);
+        cachePolicyV3.onRequest(request, response, executionContext, policyChain);
+
+        verify(policyChain, times(1)).doNext(any(), any());
+        verify(policyChain, never()).failWith(any());
+        verify(executionContext, times(1)).setAttribute(eq(ExecutionContext.ATTR_INVOKER), any(CachePolicyV3.CacheInvoker.class));
     }
 
     @Test

--- a/src/test/resources/io/gravitee/policy/cache/integration/cacheV3RefreshDisabled.json
+++ b/src/test/resources/io/gravitee/policy/cache/integration/cacheV3RefreshDisabled.json
@@ -1,0 +1,54 @@
+{
+    "id": "my-api-refresh-disabled",
+    "name": "my-api-refresh-disabled",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test-refresh-disabled",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": ["GET"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Cache",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "cache",
+                    "configuration": {
+                        "scope": "API",
+                        "cacheName": "dummy-cache",
+                        "key": "integration-test-cache-refresh-disabled",
+                        "methods": ["GET"],
+                        "responseCondition": "{#upstreamResponse.status == 200}",
+                        "allowRefreshAction": false
+                    }
+                }
+            ],
+            "post": []
+        }
+    ],
+    "resources": [
+        {
+            "name": "dummy-cache",
+            "enabled": true,
+            "type": "dummy-cache",
+            "configuration": {}
+        }
+    ]
+}

--- a/src/test/resources/io/gravitee/policy/cache/integration/cacheV4RefreshDisabled.json
+++ b/src/test/resources/io/gravitee/policy/cache/integration/cacheV4RefreshDisabled.json
@@ -1,0 +1,77 @@
+{
+    "id": "apiv4-cache-policy-refresh-disabled",
+    "name": "apiv4-cache-policy-refresh-disabled",
+    "description": "apiv4-cache-policy-refresh-disabled",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test-refresh-disabled"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default-endpoint",
+                    "type": "http-proxy",
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "cache-flow-refresh-disabled",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "STARTS_WITH"
+                }
+            ],
+            "request": [
+                {
+                    "name": "Cache",
+                    "description": "test cache policy with V4 API - refresh disabled",
+                    "enabled": true,
+                    "policy": "cache",
+                    "configuration": {
+                        "scope": "API",
+                        "cacheName": "dummy-cache",
+                        "key": "integration-test-cache-refresh-disabled",
+                        "methods": ["GET"],
+                        "responseCondition": "{#upstreamResponse.status == 200}",
+                        "allowRefreshAction": false
+                    }
+                }
+            ],
+            "response": [],
+            "subscribe": [],
+            "publish": []
+        }
+    ],
+    "resources": [
+        {
+            "name": "dummy-cache",
+            "enabled": true,
+            "type": "dummy-cache",
+            "configuration": {}
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PEN-87

**Description**

- Documents the previously undocumented `REFRESH` cache action (`X-Gravitee-Cache: REFRESH` / `?cache=REFRESH`)                                                                                                                                                                                                                                     
- Adds `allowRefreshAction`?boolean toggle (default `true`) to let API publishers disable client-triggered cache resets   

**Additional context**

**Fix demo:**


https://github.com/user-attachments/assets/c3e9c315-47e9-40f6-8bea-ab54a98979a0



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-fix-PEN-87-cache-refresh-action-toggle-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-cache/3.0.1-fix-PEN-87-cache-refresh-action-toggle-SNAPSHOT/gravitee-policy-cache-3.0.1-fix-PEN-87-cache-refresh-action-toggle-SNAPSHOT.zip)
  <!-- Version placeholder end -->
