### PR TITLE
chore: bump apim dependency to 4.12.0-alpha.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <!-- Gravitee dependencies for APIM -->
-        <gravitee-apim.version>4.12.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.12.0-alpha.1</gravitee-apim.version>
 
         <!-- Maven plugins -->
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>


### PR DESCRIPTION
Bump the APIM dependency from `4.12.0-SNAPSHOT` to the released `4.12.0-alpha.1` so this plugin no longer depends on a SNAPSHOT and can be released to Maven Central.